### PR TITLE
fix: fall back to path-based exec when fexecve fails on memfd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,4 +169,10 @@ jobs:
         set +e; out=$("$bin"); rc=$?; set -e
         echo "launcher exit=$rc stdout=[$out]"
         [ "$rc" -eq 0 ] || { echo "::error::launcher failed under emulation (exit $rc) -- fexecve-under-binfmt regression"; exit 1; }
-        [ -n "$out" ] || { echo "::error::launcher produced no output"; exit 1; }
+        # The fixture prints the selected variant's compile-time features; every x86-64
+        # variant includes sse2. Checking for it (rather than non-empty output) ensures
+        # qemu's own stdout noise (e.g. "Could not resolve /dev/fd/3") cannot pass the test.
+        case "$out" in
+          *sse2*) ;;
+          *) echo "::error::launcher did not print the variant's CPU features"; exit 1 ;;
+        esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,3 +122,51 @@ jobs:
       with:
         manifest_path: tests/test-argv/Cargo.toml
         version: main
+  # Regression test for the fexecve-under-binfmt fix (issue #29). The bug only
+  # reproduces when a launcher's in-memory variant is exec'd through a kernel
+  # binfmt_misc interpreter. On an aarch64 runner, x86_64 is the foreign arch, so a
+  # cross-built x86_64 launcher runs through binfmt_misc -> qemu-user: it fails (255)
+  # without the fix and executes the selected variant with it.
+  emulation-test:
+    name: "Emulated x86_64 launcher (issue #29)"
+    runs-on: ubuntu-24.04-arm
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: x86_64-unknown-linux-gnu
+    - uses: Swatinem/rust-cache@v2
+    - name: Register qemu binfmt handlers
+      uses: docker/setup-qemu-action@v3
+    - name: Install cross toolchain + x86 runtime libraries
+      run: |
+        # The arm runner's mirror (ports.ubuntu.com) carries no amd64 packages, so
+        # scope the existing sources to arm64 (otherwise apt 404s fetching amd64
+        # indexes there) and add an amd64-only source from archive.ubuntu.com.
+        sudo sed -i '/^Types:/a Architectures: arm64' /etc/apt/sources.list.d/ubuntu.sources
+        sudo dpkg --add-architecture amd64
+        printf 'Types: deb\nURIs: http://archive.ubuntu.com/ubuntu\nSuites: noble noble-updates\nComponents: main\nArchitectures: amd64\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' \
+          | sudo tee /etc/apt/sources.list.d/amd64.sources
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          gcc-x86-64-linux-gnu libc6-dev-amd64-cross libc6:amd64 libgcc-s1:amd64
+    - name: Build an x86_64 multivers launcher from the fixture
+      env:
+        CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: x86_64-linux-gnu-gcc
+      run: |
+        cargo install --path . --root "$RUNNER_TEMP/mv" --locked
+        "$RUNNER_TEMP/mv/bin/cargo-multivers" multivers \
+          --manifest-path tests/test-correct-build-used/Cargo.toml \
+          --target x86_64-unknown-linux-gnu \
+          --cpus x86-64,x86-64-v2,x86-64-v4 \
+          --out-dir "$RUNNER_TEMP/out"
+    - name: Run the launcher under emulation and assert it executed a variant
+      run: |
+        bin="$RUNNER_TEMP/out/test-correct-build-used"
+        grep -qa "anonymous memory file" "$bin" || { echo "::error::not a multivers launcher (variants deduplicated to one)"; exit 1; }
+        set +e; out=$("$bin"); rc=$?; set -e
+        echo "launcher exit=$rc stdout=[$out]"
+        [ "$rc" -eq 0 ] || { echo "::error::launcher failed under emulation (exit $rc) -- fexecve-under-binfmt regression"; exit 1; }
+        [ -n "$out" ] || { echo "::error::launcher produced no output"; exit 1; }

--- a/multivers-runner/src/build/linux.rs
+++ b/multivers-runner/src/build/linux.rs
@@ -1,9 +1,9 @@
 use std::convert::Infallible;
-use std::ffi::{CStr, CString};
+use std::ffi::CStr;
 use std::fs::File;
 use std::os::fd::{FromRawFd, IntoRawFd};
 
-use libc::{execve, fexecve};
+use libc::fexecve;
 
 use rustix::fd::IntoRawFd as _;
 use rustix::fd::OwnedFd;
@@ -39,15 +39,18 @@ impl Executable for Build<'_> {
 
         // `fexecve` returns only on failure. glibc implements it as
         // `execveat(fd, "", …, AT_EMPTY_PATH)`; when the build is run through an interpreter
-        // registered with binfmt_misc (e.g. an emulator), the kernel hands the descriptor to
-        // that interpreter, but a close-on-exec descriptor is already closed by then, so the
-        // call fails with ENOENT (see the BUGS section of execveat(2)). Only in that case, retry
-        // by path: the interpreter resolves `/proc/self/fd` at exec time, and the descriptor
-        // stays close-on-exec so it is not leaked into the executed program.
-        if std::io::Error::last_os_error().raw_os_error() == Some(libc::ENOENT)
-            && let Ok(fd_path) = CString::new(format!("/proc/self/fd/{fd}"))
-        {
-            unsafe { execve(fd_path.as_ptr(), argv, envp) };
+        // (a binfmt_misc handler such as an emulator, or a "#!" script), the kernel re-opens the
+        // descriptor for that interpreter, but a close-on-exec descriptor is already closed by
+        // then, so the call fails with ENOENT (see the BUGS section of execveat(2)). Clear
+        // close-on-exec and retry so the descriptor survives into the interpreter. This only
+        // happens on the interpreter path, so the executed program inherits the descriptor only
+        // in that case.
+        if std::io::Error::last_os_error().raw_os_error() == Some(libc::ENOENT) {
+            let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+            if flags >= 0 {
+                unsafe { libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) };
+                unsafe { fexecve(fd, argv, envp) };
+            }
         }
 
         let error = std::io::Error::last_os_error();

--- a/multivers-runner/src/build/linux.rs
+++ b/multivers-runner/src/build/linux.rs
@@ -36,6 +36,7 @@ impl Executable for Build<'_> {
 
         let fd = file.into_raw_fd();
         unsafe { fexecve(fd, argv, envp) };
+        let mut error = std::io::Error::last_os_error();
 
         // `fexecve` returns only on failure. glibc implements it as
         // `execveat(fd, "", …, AT_EMPTY_PATH)`; when the build is run through an interpreter
@@ -45,15 +46,16 @@ impl Executable for Build<'_> {
         // close-on-exec and retry so the descriptor survives into the interpreter. This only
         // happens on the interpreter path, so the executed program inherits the descriptor only
         // in that case.
-        if std::io::Error::last_os_error().raw_os_error() == Some(libc::ENOENT) {
+        if error.raw_os_error() == Some(libc::ENOENT) {
             let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
-            if flags >= 0 {
-                unsafe { libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) };
+            if flags >= 0
+                && unsafe { libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) } >= 0
+            {
                 unsafe { fexecve(fd, argv, envp) };
+                error = std::io::Error::last_os_error();
             }
         }
 
-        let error = std::io::Error::last_os_error();
         Err(proc_exit::Code::FAILURE.with_message(format!("Failed to execute the build: {error}")))
     }
 }

--- a/multivers-runner/src/build/linux.rs
+++ b/multivers-runner/src/build/linux.rs
@@ -1,9 +1,9 @@
 use std::convert::Infallible;
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::fs::File;
 use std::os::fd::{FromRawFd, IntoRawFd};
 
-use libc::fexecve;
+use libc::{execve, fexecve};
 
 use rustix::fd::IntoRawFd as _;
 use rustix::fd::OwnedFd;
@@ -34,7 +34,17 @@ impl Executable for Build<'_> {
                 .with_message("Failed to write the build to an anonymous memory file")
         })?;
 
-        let r = unsafe { fexecve(file.into_raw_fd(), argv, envp) };
+        let fd = file.into_raw_fd();
+        let r = unsafe { fexecve(fd, argv, envp) };
+
+        // Reaching here means `fexecve` failed (on success it never returns). On modern glibc
+        // `fexecve` issues `execveat(fd, "", …, AT_EMPTY_PATH)`, which returns ENOENT for an
+        // anonymous memfd under the amd64 binfmt_misc emulation used by Docker Desktop on Apple
+        // Silicon. A path-based exec of the same still-valid descriptor via `/proc/self/fd` works
+        // there, so fall back to it before giving up.
+        if let Ok(fd_path) = CString::new(format!("/proc/self/fd/{fd}")) {
+            unsafe { execve(fd_path.as_ptr(), argv, envp) };
+        }
 
         Err(proc_exit::Exit::new(proc_exit::Code::new(r)))
     }

--- a/multivers-runner/src/build/linux.rs
+++ b/multivers-runner/src/build/linux.rs
@@ -35,17 +35,22 @@ impl Executable for Build<'_> {
         })?;
 
         let fd = file.into_raw_fd();
-        let r = unsafe { fexecve(fd, argv, envp) };
+        unsafe { fexecve(fd, argv, envp) };
 
-        // Reaching here means `fexecve` failed (on success it never returns). On modern glibc
-        // `fexecve` issues `execveat(fd, "", …, AT_EMPTY_PATH)`, which returns ENOENT for an
-        // anonymous memfd under the amd64 binfmt_misc emulation used by Docker Desktop on Apple
-        // Silicon. A path-based exec of the same still-valid descriptor via `/proc/self/fd` works
-        // there, so fall back to it before giving up.
-        if let Ok(fd_path) = CString::new(format!("/proc/self/fd/{fd}")) {
+        // `fexecve` returns only on failure. glibc implements it as
+        // `execveat(fd, "", …, AT_EMPTY_PATH)`; when the build is run through an interpreter
+        // registered with binfmt_misc (e.g. an emulator), the kernel hands the descriptor to
+        // that interpreter, but a close-on-exec descriptor is already closed by then, so the
+        // call fails with ENOENT (see the BUGS section of execveat(2)). Only in that case, retry
+        // by path: the interpreter resolves `/proc/self/fd` at exec time, and the descriptor
+        // stays close-on-exec so it is not leaked into the executed program.
+        if std::io::Error::last_os_error().raw_os_error() == Some(libc::ENOENT)
+            && let Ok(fd_path) = CString::new(format!("/proc/self/fd/{fd}"))
+        {
             unsafe { execve(fd_path.as_ptr(), argv, envp) };
         }
 
-        Err(proc_exit::Exit::new(proc_exit::Code::new(r)))
+        let error = std::io::Error::last_os_error();
+        Err(proc_exit::Code::FAILURE.with_message(format!("Failed to execute the build: {error}")))
     }
 }


### PR DESCRIPTION
On modern glibc, fexecve issues execveat(fd, "", ..., AT_EMPTY_PATH). Under the amd64 binfmt_misc emulation used by Docker Desktop on Apple Silicon, that syscall returns ENOENT for an anonymous memfd, so the launcher exits 255 with no output. A path-based exec of the same descriptor via /proc/self/fd works there.

Keep fexecve as the fast path and, only when it fails, fall back to execve on /proc/self/fd/{fd}. The failed fexecve does not replace the process, so the descriptor is still valid and is reused directly; argv and envp are passed through unchanged.

Fixes #29.  Verified by building a CLI crate with this version of cargo-multivers inside an x86 docker container on an M2 (aarch64) mac, then running.  Goes from exit 255 to running as intended.