### PR TITLE
Add use stmt for std::arch::#is_feature_detected;

### DIFF
--- a/multivers-runner/build.rs
+++ b/multivers-runner/build.rs
@@ -162,7 +162,6 @@ impl BuildsDescription {
         })?;
 
         let n_builds = patches.len();
-        let use_stmt= quote! { use std::arch::#is_feature_detected; };
         let tokens = quote! {
             #[allow(unused)]
             use std::arch::#is_feature_detected;

--- a/multivers-runner/build.rs
+++ b/multivers-runner/build.rs
@@ -162,7 +162,10 @@ impl BuildsDescription {
         })?;
 
         let n_builds = patches.len();
+        let use_stmt= quote! { use std::arch::#is_feature_detected; };
         let tokens = quote! {
+            #use_stmt
+
             const SOURCE: Build<'_> = Build {
                 compressed: include_bytes!(concat!(env!("OUT_DIR"), "/", #source_filename)),
                 all_features_supported: || true #(&& #is_feature_detected!(#source_features))*,

--- a/multivers-runner/build.rs
+++ b/multivers-runner/build.rs
@@ -164,7 +164,8 @@ impl BuildsDescription {
         let n_builds = patches.len();
         let use_stmt= quote! { use std::arch::#is_feature_detected; };
         let tokens = quote! {
-            #use_stmt
+            #[allow(unused)]
+            use std::arch::#is_feature_detected;
 
             const SOURCE: Build<'_> = Build {
                 compressed: include_bytes!(concat!(env!("OUT_DIR"), "/", #source_filename)),


### PR DESCRIPTION
Fixes #33

The generate_sources works for x86 because the is_x86_feature_detected macro is reexported in the std lib however the corresponding macro's for other architectures are under std::arch package (that is a pretty lame bias in the std lib tbh). However, for aarch64 it fails because the macro isn't found. 

This pr fixes that by adding a use statement for the #is_feature_detected macro.