### PR TITLE
Update ignored_features for aarch64 features for neoverse cpu's that …

### DIFF
--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -46,6 +46,15 @@ impl Rustc {
         let ignored_features = [
             // See https://github.com/rust-lang/rust/issues/116344
             "x87",
+            // AArch64 features that rustc emits as target_feature cfg values for Neoverse CPUs
+            // but which is_aarch64_feature_detected! cannot detect at run-time, either because
+            // they are privileged/kernel-mode extensions or are otherwise not exposed to user space.
+            "lor",   // Limited Ordering Regions (ARMv8.1) — memory ordering control, EL1/EL2
+            "pan",   // Privileged Access Never (ARMv8.1) — EL1/EL2 mode extension
+            "pmuv3", // Performance Monitor Unit v3 — privileged performance counters
+            "ras",   // Reliability, Availability and Serviceability (ARMv8.2) — firmware/kernel
+            "spe",   // Statistical Profiling Extension (ARMv8.2) — privileged hardware profiling
+            "vh",    // Virtualization Host Extensions (ARMv8.1) — EL2 hypervisor feature
         ];
 
         let cfg = Self::command()

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -48,12 +48,12 @@ impl Rustc {
             "x87",
             // AArch64 features that rustc emits as target_feature cfg values for Neoverse CPUs
             // but which `is_aarch64_feature_detected!` cannot detect at run-time or are unknown.
-            "lor",   // Limited Ordering Regions (ARMv8.1) — memory ordering control, EL1/EL2
-            "pan",   // Privileged Access Never (ARMv8.1) — EL1/EL2 mode extension
-            "pmuv3", // Performance Monitor Unit v3 — privileged performance counters
-            "ras",   // Reliability, Availability and Serviceability (ARMv8.2) — firmware/kernel
-            "spe",   // Statistical Profiling Extension (ARMv8.2) — privileged hardware profiling
-            "vh",    // Virtualization Host Extensions (ARMv8.1) — EL2 hypervisor feature
+            "lor",   // Limited Ordering Regions (ARMv8.1)
+            "pan",   // Privileged Access Never (ARMv8.1)
+            "pmuv3", // Performance Monitor Unit v3
+            "ras",   // Reliability, Availability and Serviceability (ARMv8.2)
+            "spe",   // Statistical Profiling Extension (ARMv8.2)
+            "vh",    // Virtualization Host Extensions (ARMv8.1)
         ];
 
         let cfg = Self::command()

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -47,7 +47,7 @@ impl Rustc {
             // See https://github.com/rust-lang/rust/issues/116344
             "x87",
             // AArch64 features that rustc emits as target_feature cfg values for Neoverse CPUs
-            // but which is_aarch64_feature_detected! cannot detect at run-time, either because
+            // but which `is_aarch64_feature_detected!` cannot detect at run-time or are unknown.
             // they are privileged/kernel-mode extensions or are otherwise not exposed to user space.
             "lor",   // Limited Ordering Regions (ARMv8.1) — memory ordering control, EL1/EL2
             "pan",   // Privileged Access Never (ARMv8.1) — EL1/EL2 mode extension

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -48,7 +48,6 @@ impl Rustc {
             "x87",
             // AArch64 features that rustc emits as target_feature cfg values for Neoverse CPUs
             // but which `is_aarch64_feature_detected!` cannot detect at run-time or are unknown.
-            // they are privileged/kernel-mode extensions or are otherwise not exposed to user space.
             "lor",   // Limited Ordering Regions (ARMv8.1) — memory ordering control, EL1/EL2
             "pan",   // Privileged Access Never (ARMv8.1) — EL1/EL2 mode extension
             "pmuv3", // Performance Monitor Unit v3 — privileged performance counters


### PR DESCRIPTION
Fixes #35 by ignoring certain features that the is_aarch64_feature_detected macro doesn't know about.