### PR TITLE
Fix issue with hardcoded i8 for argv/envp causing failures on aarch64

### DIFF
--- a/multivers-runner/src/build.rs
+++ b/multivers-runner/src/build.rs
@@ -1,4 +1,5 @@
 use std::convert::Infallible;
+use std::ffi::c_char;
 use std::io::{Read, Write};
 
 include!(concat!(env!("OUT_DIR"), "/builds.rs"));
@@ -103,8 +104,8 @@ pub trait Executable {
     unsafe fn exec(
         self,
         argc: i32,
-        argv: *const *const i8,
-        envp: *const *const i8,
+        argv: *const *const c_char,
+        envp: *const *const c_char,
     ) -> Result<Infallible, proc_exit::Exit>;
 }
 

--- a/multivers-runner/src/build/generic.rs
+++ b/multivers-runner/src/build/generic.rs
@@ -1,4 +1,5 @@
 use std::convert::Infallible;
+use std::ffi::c_char;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
@@ -10,8 +11,8 @@ impl Executable for Build<'_> {
     unsafe fn exec(
         self,
         _argc: i32,
-        _argv: *const *const i8,
-        _envp: *const *const i8,
+        _argv: *const *const c_char,
+        _envp: *const *const c_char,
     ) -> Result<Infallible, proc_exit::Exit> {
         let mut args = std::env::args_os();
         let exe_filename = args

--- a/multivers-runner/src/build/linux.rs
+++ b/multivers-runner/src/build/linux.rs
@@ -1,5 +1,5 @@
 use std::convert::Infallible;
-use std::ffi::CStr;
+use std::ffi::{CStr, c_char};
 use std::fs::File;
 use std::os::fd::{FromRawFd, IntoRawFd};
 
@@ -15,8 +15,8 @@ impl Executable for Build<'_> {
     unsafe fn exec(
         self,
         argc: i32,
-        argv: *const *const i8,
-        envp: *const *const i8,
+        argv: *const *const c_char,
+        envp: *const *const c_char,
     ) -> Result<Infallible, proc_exit::Exit> {
         let memfd_name = if argc > 0 {
             unsafe { CStr::from_ptr(*argv) }

--- a/multivers-runner/src/lib.rs
+++ b/multivers-runner/src/lib.rs
@@ -4,6 +4,8 @@
 
 mod build;
 
+use std::ffi::c_char;
+
 use build::{Build, Executable};
 
 /// Function called at program startup.
@@ -26,13 +28,13 @@ use build::{Build, Executable};
 /// - Each element of `argv` and `envp` must be valid for reads of bytes up to and including the null terminator.
 #[unsafe(no_mangle)]
 #[cfg(not(test))]
-pub unsafe extern "C" fn main(argc: i32, argv: *const *const i8, envp: *const *const i8) {
+pub unsafe extern "C" fn main(argc: i32, argv: *const *const c_char, envp: *const *const c_char) {
     let result = unsafe { run(argc, argv, envp) };
 
     proc_exit::exit(result);
 }
 
-unsafe fn run(argc: i32, argv: *const *const i8, envp: *const *const i8) -> proc_exit::ExitResult {
+unsafe fn run(argc: i32, argv: *const *const c_char, envp: *const *const c_char) -> proc_exit::ExitResult {
     #[cfg(feature = "debug")]
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug")).init();
 

--- a/multivers-runner/src/lib.rs
+++ b/multivers-runner/src/lib.rs
@@ -34,7 +34,11 @@ pub unsafe extern "C" fn main(argc: i32, argv: *const *const c_char, envp: *cons
     proc_exit::exit(result);
 }
 
-unsafe fn run(argc: i32, argv: *const *const c_char, envp: *const *const c_char) -> proc_exit::ExitResult {
+unsafe fn run(
+    argc: i32,
+    argv: *const *const c_char,
+    envp: *const *const c_char,
+) -> proc_exit::ExitResult {
     #[cfg(feature = "debug")]
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug")).init();
 


### PR DESCRIPTION
Fixes #38

Replaced every *const *const i8 / *const i8 with *const *const c_char / *const c_char, using std::ffi::c_char (stable since 1.64) which is the platform-correct alias — i8 on x86_64, u8 on aarch64.  
